### PR TITLE
Added abstract to pod

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension Plack::Middleware::File::Less
 
+0.03
+    - Added abstract to pod
+
 0.02 2013-01-23 10:44:28 Naoya Ito <i.naoya@gmail.com>
      - forked
      - Use 'lessc' executable if installed.

--- a/lib/Plack/Middleware/File/Less.pm
+++ b/lib/Plack/Middleware/File/Less.pm
@@ -75,6 +75,10 @@ sub call {
 
 1;
 
+=head1 NAME
+
+Plack::Middleware::File::Less - compile LESS templates into CSS stylesheets
+
 =head1 SYNOPSIS
 
   use Plack::App::File;


### PR DESCRIPTION
Hi,

I added an abstract to your pod. Because it couldn't find an abstract, MetaCPAN doesn't present your module in the usual way, in search results. Other tools may also have problems processing your dist.

Cheers,
Neil
