### PR TITLE
Add the Module::Install dependencies in the Makefile.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,11 @@
 use inc::Module::Install;
+
+# Module Install necessary modules
+
+use Module::Install::Repository;
+use Module::Install::ReadmeFromPod;
+use Module::Install::CPANfile;
+
 name 'Plack-Middleware-File-Less';
 all_from 'lib/Plack/Middleware/File/Less.pm';
 readme_from 'lib/Plack/Middleware/File/Less.pm';

--- a/README
+++ b/README
@@ -1,3 +1,7 @@
+NAME
+    Plack::Middleware::File::Less - compile LESS templates into CSS
+    stylesheets
+
 SYNOPSIS
       use Plack::App::File;
       use Plack::Builder;


### PR DESCRIPTION
Meanwhile I was trying to run the Makefile.PL and run the tests, I had some time until I figured out what is the plugins used by Module::Install to generate it. 

As suggested on the doc of Module::Install I put the plugins to be used by Makefile, as a hint to developer.