### PR TITLE
Fix the travis config, generate a cpan.pm before the build/test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ perl:
   - "5.16"
   - "5.14"
   - "5.12"
+env: PERL_MM_USE_DEFAULT=1
 before_install:
+  - cpan o conf init
   - cpanm Module::Install::Repository
   - cpanm Module::Install::ReadmeFromPod
   - cpanm Module::Install::CPANfile


### PR DESCRIPTION
I`m fixing the travis ci automatic build, adding the env var to perl use defaults, this makes the cpan configuration do not ask questions. This makes the build works.