### PR TITLE
Added CSS::LESSp to required modules to allow successful fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ local/
 .carton/
 MYMETA.json
 
+## Ignore backup files
+*~
+
 ### /Users/naoya/.gitignore-boilerplates/perl.gitignore
 
 blib/
@@ -17,6 +20,7 @@ Makefile
 Makefile.old
 MANIFEST.bak
 META.yml
+META.json
 MYMETA.yml
 nytprof.out
 pm_to_blib

--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Perl extension Plack::Middleware::File::Less
 
 0.03
     - Added abstract to pod
+    - Added CSS::LESSp to dependencies to ensure module is available
+      for fallback when the 'lessc' executable is not available
 
 0.02 2013-01-23 10:44:28 Naoya Ito <i.naoya@gmail.com>
      - forked

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,7 +1,13 @@
 Changes
+inc/Module/CPANfile.pm
+inc/Module/CPANfile/Environment.pm
+inc/Module/CPANfile/Prereq.pm
+inc/Module/CPANfile/Prereqs.pm
+inc/Module/CPANfile/Requirement.pm
 inc/Module/Install.pm
 inc/Module/Install/Base.pm
 inc/Module/Install/Can.pm
+inc/Module/Install/CPANfile.pm
 inc/Module/Install/Fetch.pm
 inc/Module/Install/Include.pm
 inc/Module/Install/Makefile.pm
@@ -10,11 +16,10 @@ inc/Module/Install/ReadmeFromPod.pm
 inc/Module/Install/Repository.pm
 inc/Module/Install/Win32.pm
 inc/Module/Install/WriteAll.pm
-inc/Test/Builder/Module.pm
-inc/Test/Requires.pm
 lib/Plack/Middleware/File/Less.pm
 Makefile.PL
 MANIFEST			This list of files
+META.json
 META.yml
 README
 t/bar.css

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,0 +1,3 @@
+.travis.yml
+carton.lock
+cpanfile

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,6 +5,7 @@ use inc::Module::Install;
 use Module::Install::Repository;
 use Module::Install::ReadmeFromPod;
 use Module::Install::CPANfile;
+use Module::Install::Can;
 
 name 'Plack-Middleware-File-Less';
 all_from 'lib/Plack/Middleware/File/Less.pm';
@@ -13,4 +14,8 @@ readme_from 'lib/Plack/Middleware/File/Less.pm';
 auto_include_deps;
 auto_set_repository;
 cpanfile;
+unless (can_run('lessc'))
+{
+  requires('CSS::LESSp');
+}
 WriteAll;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,7 +5,6 @@ use inc::Module::Install;
 use Module::Install::Repository;
 use Module::Install::ReadmeFromPod;
 use Module::Install::CPANfile;
-use Module::Install::Can;
 
 name 'Plack-Middleware-File-Less';
 all_from 'lib/Plack/Middleware/File/Less.pm';
@@ -14,8 +13,4 @@ readme_from 'lib/Plack/Middleware/File/Less.pm';
 auto_include_deps;
 auto_set_repository;
 cpanfile;
-unless (can_run('lessc'))
-{
-  requires('CSS::LESSp');
-}
 WriteAll;

--- a/cpanfile
+++ b/cpanfile
@@ -1,8 +1,19 @@
 requires 'Plack';
 requires 'CSS::LESSp';
 
+## test_requires
 on 'test' => sub {
     requires 'Test::More';
     requires 'Test::Requires';
     requires 'Devel::Cover';
+    requires 'CSS::LESSp';
+};
+
+## author_requires
+on 'develop' => sub {
+    requires 'inc::Install::Module';
+    requires 'Module::Install::Repository';
+    requires 'Install::Module::ReadmeFromPod';
+    requires 'Module::Install::CPANfile';
+    requires 'Module::Install::Can';
 };

--- a/cpanfile
+++ b/cpanfile
@@ -1,3 +1,4 @@
+## runtime requirements
 requires 'Plack';
 requires 'CSS::LESSp';
 
@@ -16,4 +17,5 @@ on 'develop' => sub {
     requires 'Install::Module::ReadmeFromPod';
     requires 'Module::Install::CPANfile';
     requires 'Module::Install::Can';
+    requires 'CSS::LESSp';
 };

--- a/lib/Plack/Middleware/File/Less.pm
+++ b/lib/Plack/Middleware/File/Less.pm
@@ -5,7 +5,7 @@ package Plack::Middleware::File::Less;
 use strict;
 use warnings;
 use 5.008_001;
-our $VERSION = '0.02';
+our $VERSION = '0.03';
 
 use parent qw(Plack::Middleware);
 use Plack::Util;


### PR DESCRIPTION
* Added the CSS::LESSp to the cpanfile as a runtime, test, and author requirement to ensure module was available for fallback when 'lessc' executable was not available. This should allow the module to install successfully on systems without the 'lessc' executable

* Created MANIFEST.SKIP and updated MANIFEST to address issues encountered when I ran 'make dist'

* With the v0.02 module currently on CPAN, I experienced the issue reported in [RT Ticket 9194](https://rt.cpan.org/Public/Bug/Display.html?id=91934). After building a new distribution using 'make dist' I no longer have this problem. I suspect this is because I am using a newer version of inc::Module::Install that does not bundle Test::Builder