### PR TITLE
Corrected problems created in 0.03

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension Plack::Middleware::File::Less
 
+0.04
+    - Added missing cpanfile to the tarball
+    
 0.03
     - Added abstract to pod
     - Added CSS::LESSp to dependencies to ensure module is available

--- a/MANIFEST
+++ b/MANIFEST
@@ -25,3 +25,4 @@ README
 t/bar.css
 t/foo.less
 t/less.t
+cpanfile

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,3 +1,2 @@
 .travis.yml
 carton.lock
-cpanfile

--- a/lib/Plack/Middleware/File/Less.pm
+++ b/lib/Plack/Middleware/File/Less.pm
@@ -5,7 +5,7 @@ package Plack::Middleware::File::Less;
 use strict;
 use warnings;
 use 5.008_001;
-our $VERSION = '0.03';
+our $VERSION = '0.04';
 
 use parent qw(Plack::Middleware);
 use Plack::Util;


### PR DESCRIPTION
- 0.03 had the cpanfile in the MANIFEST.SKIP file and it should be in MANIFEST. This caused an error when trying to generate the Makefile from Makefile.PL. Verified tarball builds and installs on Ubuntu and Windows 7
